### PR TITLE
Add shared-mime-info to dependencies for mimemagic 0.3.7 breaking change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,5 @@ RUN apt-get update \
     curl \
     ca-certificates \
     libmcrypt4 \
+    shared-mime-info \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## For `mimemagic` gem 0.3.7 breaking change

https://github.com/mimemagicrb/mimemagic/blob/master/CHANGELOG.md#037-2021-03-25

> rake aborted!
Could not find MIME type database in the following locations: ["/usr/local/share/mime/packages/freedesktop.org.xml", "/opt/homebrew/share/mime/packages/freedesktop.org.xml", "/usr/share/mime/packages/freedesktop.org.xml"]
Ensure you have either installed the shared-mime-types package for your distribution, or
obtain a version of freedesktop.org.xml and set FREEDESKTOP_MIME_TYPES_PATH to the location