### PR TITLE
Install shared-mime-info as dependencies for mimemagic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,5 @@ RUN apt-get update \
     curl \
     ca-certificates \
     libmcrypt4 \
+    shared-mime-info \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
因為 mimemagic 的授權爭議，現在如果用到 mimemagic 需要額外安裝  shared-mime-info