### PR TITLE
Install shared-mime-info as dependencies for mimemagic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM polydice/base:0.16.0
+FROM polydice/base:0.17.0
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
因為 mimemagic 的授權爭議，現在如果用到 mimemagic 需要額外安裝 shared-mime-info

