### PR TITLE
support ARM64 with official Ruby + jemalloc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Build and Publish
 on:
   create:
     tags:
-    - '*'
+      - '*'
 
 jobs:
   build-and-push-docker-image:
@@ -12,24 +12,61 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: polydice/base
           tags: type=ref,event=tag
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build image and push to Docker Hub
-        uses: docker/build-push-action@v3
+      - name: Build and push
+        uses: docker/build-push-action@v6
         with:
           push: true
           context: .
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
+
+  sync-to-ecr:
+    name: Sync to ECR Public
+    needs: build-and-push-docker-image
+    runs-on: ubuntu-latest
+    if: success()
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR Public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Sync multi-arch image to ECR
+        run: |
+          set -e
+          docker buildx imagetools create \
+            --tag public.ecr.aws/z1n0q3w1/base:${{ github.ref_name }} \
+            polydice/base:${{ github.ref_name }}
+          echo "Successfully synced to ECR Public"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,15 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
 
+      - name: Build and push testing variant
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          context: .
+          file: ./Dockerfile.testing
+          platforms: linux/amd64,linux/arm64
+          tags: polydice/base:${{ github.ref_name }}-testing
+
   sync-to-ecr:
     name: Sync to ECR Public
     needs: build-and-push-docker-image
@@ -69,4 +78,7 @@ jobs:
           docker buildx imagetools create \
             --tag public.ecr.aws/z1n0q3w1/base:${{ github.ref_name }} \
             polydice/base:${{ github.ref_name }}
+          docker buildx imagetools create \
+            --tag public.ecr.aws/z1n0q3w1/base:${{ github.ref_name }}-testing \
+            polydice/base:${{ github.ref_name }}-testing
           echo "Successfully synced to ECR Public"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,35 @@
 ARG RUBY_VERSION=2.7.8
-ARG VARIANT=jemalloc-slim
-FROM quay.io/evl.ms/fullstaq-ruby:${RUBY_VERSION}-${VARIANT} as base
+FROM ruby:${RUBY_VERSION}-slim
 
-ARG BUNDLER_VERSION=2.4.20
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# jemalloc for better memory management
+RUN apt-get update && apt-get install -y --no-install-recommends libjemalloc2 \
+  && JEMALLOC_PATH=$(find /usr/lib -name "libjemalloc.so.2" | head -1) \
+  && [ -n "$JEMALLOC_PATH" ] || (echo "libjemalloc.so.2 not found" && exit 1) \
+  && ln -sf "$JEMALLOC_PATH" /usr/lib/libjemalloc.so.2 \
+  && rm -rf /var/lib/apt/lists/*
+ENV LD_PRELOAD=/usr/lib/libjemalloc.so.2
+
+# Install build tools and native extension dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libpq-dev \
+    libffi-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+ARG BUNDLER_VERSION=2.4.22
 RUN gem install -N bundler -v ${BUNDLER_VERSION}
 
 ARG NODE_VERSION=18.18.0
 ARG YARN_VERSION=1.22.22
 ARG PNPM_VERSION=9.9.0
-RUN curl https://get.volta.sh | bash
-ENV VOLTA_HOME /root/.volta
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
+  && rm -rf /var/lib/apt/lists/* \
+  && curl -fsSL https://get.volta.sh | bash
+ENV VOLTA_HOME=/root/.volta
 ENV VOLTA_FEATURE_PNPM=1
-ENV PATH $VOLTA_HOME/bin:/usr/local/bin:$PATH
+ENV PATH=$VOLTA_HOME/bin:/usr/local/bin:$PATH
 RUN volta install node@${NODE_VERSION} && volta install yarn@${YARN_VERSION} && volta install pnpm@${PNPM_VERSION}
 
 RUN apt-get update \
@@ -23,28 +41,24 @@ RUN apt-get update \
     graphicsmagick \
     file \
     tar \
-    curl \
-    ca-certificates \
-    libmcrypt4 \
     shared-mime-info \
+    libmcrypt4 \
   && rm -rf /var/lib/apt/lists/*
 
+# Don't add g++/make to buildDeps, or purge will remove build-essential
+WORKDIR /tmp
 RUN set -ex \
-  \
-  && buildDeps=' \
-    g++ \
-    make \
-    cmake \
-    python \
-  ' \
+  && buildDeps='cmake python3' \
   && apt-get update \
   && apt-get install -y --no-install-recommends $buildDeps \
   && rm -rf /var/lib/apt/lists/* \
-  \
-  && curl -L https://github.com/BYVoid/OpenCC/archive/refs/tags/ver.1.1.9.tar.gz | tar -xz \
-  && cd OpenCC-ver.1.1.9 \ 
-  && REL_BUILD_DOCUMENTATION=OFF make install \
-  \
-  && apt-get purge -y --auto-remove $buildDeps \
-  && cd ../ \
+  && curl -L https://github.com/BYVoid/OpenCC/archive/refs/tags/ver.1.1.9.tar.gz | tar -xz
+
+WORKDIR /tmp/OpenCC-ver.1.1.9
+RUN REL_BUILD_DOCUMENTATION=OFF make install
+
+WORKDIR /tmp
+RUN apt-get purge -y --auto-remove cmake python3 \
   && rm -rf OpenCC-ver.1.1.9
+
+WORKDIR /app

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -1,0 +1,13 @@
+FROM polydice/base:0.32.0-rc5
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    git \
+    openssh-client \
+    libpq-dev \
+    libxml2-dev \
+    libxslt1-dev \
+    libsasl2-dev \
+    libmcrypt-dev \
+    build-essential \
+  && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -5,7 +5,15 @@ Polydice's base docker image for Rails applications.
 ## Variants
 
 - `x.y.z` - Standard image for running on production
-- `x.y.z-testing` - Image for testing which includes additional packages.
+- `x.y.z-testing` - Image for testing which includes additional packages:
+  - git
+  - openssh-client
+  - libpq-dev
+  - libxml2-dev
+  - libxslt1-dev
+  - libsasl2-dev
+  - libmcrypt-dev
+  - build-essential
 
 ## Architectures
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,36 @@ Polydice's base docker image for Rails applications.
 - `x.y.z` - Standard image for running on production
 - `x.y.z-testing` - Image for testing which includes additional packages.
 
+## Architectures
+
+- `linux/amd64` (x86_64)
+- `linux/arm64` (Graviton, Apple Silicon)
+
 ## Versions
 
-| Version | Ruby  | Node.js | Yarn    | Bundler | pnpm  |
-|---------|-------|---------|---------|---------|-------|
-| 0.31.2  | 2.7.8 | 18.18.0 | 1.22.22 | 2.4.20  | 9.9.0 |
-| 0.31.1  | 2.7.8 | 18.18.0 | 1.22.19 | 2.4.20  | 8.8.0 |
-| 0.31.0  | 2.7.7 | 18.18.0 | 1.22.19 | 2.4.5   | 8.8.0 |
-| 0.30.3  | 2.7.7 | 14.21.2 | 1.22.19 | 2.4.5   |       |
+| Version | Ruby  | Node.js | Yarn    | Bundler | pnpm  | ARM64 |
+|---------|-------|---------|---------|---------|-------|-------|
+| 0.32.0  | 2.7.8 | 18.18.0 | 1.22.22 | 2.4.22  | 9.9.0 | ✅    |
+| 0.31.2  | 2.7.8 | 18.18.0 | 1.22.22 | 2.4.20  | 9.9.0 | ❌    |
+| 0.31.1  | 2.7.8 | 18.18.0 | 1.22.19 | 2.4.20  | 8.8.0 | ❌    |
+| 0.31.0  | 2.7.7 | 18.18.0 | 1.22.19 | 2.4.5   | 8.8.0 | ❌    |
+| 0.30.3  | 2.7.7 | 14.21.2 | 1.22.19 | 2.4.5   |       | ❌    |
+
+## Release
+
+1. Update version in README.md
+2. Commit and push tag:
+   ```bash
+   git tag <version>
+   git push origin <version>
+   ```
+3. GitHub Actions will automatically:
+   - Build multi-arch images (amd64 + arm64)
+   - Push to DockerHub
+   - Sync to ECR Public
+
+## Changes in 0.32.0
+
+- Switched from fullstaq-ruby to official Ruby image
+- Added jemalloc via `LD_PRELOAD`
+- Added ARM64 (linux/arm64) support


### PR DESCRIPTION
## Summary

Add ARM64 architecture support to enable iCook, tv, market, newsroom, and other Rails projects to run on Graviton instances.

## Changes

### Dockerfile
- Switch from fullstaq-ruby to official `ruby:2.7.8-slim` (fullstaq doesn't support ARM64)
- Manually install `libjemalloc2` with `LD_PRELOAD` for memory optimization

### .github/workflows/release.yml
- Add QEMU + buildx for multi-arch builds
- Build both `linux/amd64` and `linux/arm64`
- Add automated ECR Public sync job
- Update actions to latest versions

### README.md
- Add ARM64 support documentation
- Update release workflow

## Release Flow

```bash
# 1. Merge PR
# 2. Create and push tag
git tag 0.32.0
git push origin 0.32.0

# 3. GitHub Actions automatically builds and syncs to both DockerHub and ECR
```

## Related

- Shortcut ticket [sc-97578](https://app.shortcut.com/tnlmg/story/97578)