### PR TITLE
Switch GitHub Actions to OIDC for AWS authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,13 +55,15 @@ jobs:
     needs: build-and-push-docker-image
     runs-on: ubuntu-latest
     if: success()
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::635002287587:role/GitHubActionsDeployRole
           aws-region: us-east-1
 
       - name: Login to Amazon ECR Public


### PR DESCRIPTION
Replace long-lived AWS access keys with IAM role assumption via OIDC.

Refs: [sc-102055](https://app.shortcut.com/tnlmg/story/102055)